### PR TITLE
Fix cuda 9.0 build

### DIFF
--- a/src/nccl.h
+++ b/src/nccl.h
@@ -9,12 +9,7 @@
 
 #include <cuda_runtime.h>
 
-#if CUDART_VERSION >= 7050
-#include <cuda_fp16.h>
-#define CUDA_HAS_HALF 1
-#else
 #undef CUDA_HAS_HALF
-#endif
 
 #define NCCL_EXPORTED
 


### PR DESCRIPTION
This is a short-term fix.

The intention is for XGBoost to optionally depend on nccl 2.0 and remove nccl 1 in future.